### PR TITLE
Continue support for subpaths

### DIFF
--- a/lib/build.coffee
+++ b/lib/build.coffee
@@ -108,6 +108,12 @@ module.exports = (cb) ->
 
     use(true, prefixoid, {
       prefix: config.pathPrefix
+      tag: 'div'
+      attr: 'data-url-template'
+    })
+
+    use(true, prefixoid, {
+      prefix: config.pathPrefix
       tag: 'link'
     })
 


### PR DESCRIPTION
This is with reference to the dynamic pages dropdown switch generator using data-url-template attributes to pass URLs to client JS.

Change-type: patch
Signed-off-by: Chris Crocker-White <chriscw@balena.io>