### PR TITLE
meta: Add support to expand variables in excerpt

### DIFF
--- a/lib/metalsmith-plugins.coffee
+++ b/lib/metalsmith-plugins.coffee
@@ -26,7 +26,9 @@ module.exports = (config, navTree) ->
     obj = files[file]
     _.assign(obj, getValue(config.metaExtra, file, obj))
     title = obj.title or extractTitleFromText(obj.contents.toString())
+    excerpt = obj.excerpt
     obj.title = HbHelper.render(title, obj)
+    obj.excerpt = HbHelper.render(excerpt, obj)
     [ obj.ref, obj.ext ] = filenameToRef(file)
     fileByRef[obj.ref] = obj
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Doxx — a static docs generator with dynamic pages support.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"This repo has no tests specified.\" && exit 0"
   },
   "bin": {
     "doxx": "./doxx.js"


### PR DESCRIPTION
This allows variables to be parsed in `{{ excerpt }}` in headers.

Tested this works locally on the balena/docs repo.

Resolves: https://github.com/balena-io/docs/issues/1247

Change-type: patch
Signed-off-by: Gareth Davies gareth@balena.io