### PR TITLE
Build coffeescript files before publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 .#*
 
 .DS_Store
+/build

--- a/index.js
+++ b/index.js
@@ -1,2 +1,1 @@
-require('coffee-script/register')
-module.exports = require('./lib')
+module.exports = require('./build')

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Doxx — a static docs generator with dynamic pages support.",
   "main": "index.js",
   "scripts": {
+    "prepare": "coffee -o build -c lib",
     "test": "echo \"This repo has no tests specified.\" && exit 0"
   },
   "bin": {
@@ -22,7 +23,6 @@
   "dependencies": {
     "@resin.io/doxx-handlebars-helper": "^0.1.0",
     "@resin.io/doxx-utils": "^0.1.2",
-    "coffee-script": "^1.10.0",
     "consolidate": "^0.14.0",
     "handlebars-helpers": "^0.6.1",
     "lodash": "^4.12.0",
@@ -39,7 +39,8 @@
     "swig": "^1.4.2"
   },
   "devDependencies": {
-    "watch": "^0.18.0",
-    "express": "^4.13.4"
+    "coffeescript": "^1.12.7",
+    "express": "^4.13.4",
+    "watch": "^0.18.0"
   }
 }


### PR DESCRIPTION
This avoids the needs to compile on every run

Change-type: patch