### PR TITLE
patch: Exit the process when error is detected

### DIFF
--- a/doxx.js
+++ b/doxx.js
@@ -13,6 +13,7 @@ var Doxx = require('./index')
 
 Doxx(config).build(function(err) {
   if (err) {
-    throw err
+    console.err(err)
+    process.exit(1)
   }
 })


### PR DESCRIPTION
This change was needed because of errors going undetected when doxx was being called to build the docs. Doxx would error out but the command would still exit with exit code 1. This PR fixes things downstream: https://github.com/balena-io/docs/pull/2304

Context: https://www.flowdock.com/app/rulemotion/resin-devops/threads/lRgvlRyPy6MLl4c5dsgI-vVbnEw
